### PR TITLE
fix: package version in lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-emojicodes"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "emojis",


### PR DESCRIPTION
This is made necessary by:
```console
❯ cargo build --locked
error: the lock file /home/blaggacao/src/github.com/blyxyas/mdbook-emojicodes/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```